### PR TITLE
Allow passing structured cloneable data to HTMLPortalElement/activate

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -80,7 +80,8 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
 
   <section algorithm="portal-browsing-context-activate">
     To <dfn>activate a portal browsing context</dfn> |portalBrowsingContext| in
-    place of |predecessorBrowsingContext|, run the following steps [=in parallel=]:
+    place of |predecessorBrowsingContext| with data |serializedData|, run the
+    following steps [=in parallel=]:
 
     1. Let |successorWindow| be |portalBrowsingContext|'s associated {{WindowProxy}}'s \[[Window]] internal slot value.
 
@@ -94,9 +95,17 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
 
         1. [=PortalHost/hidden|Hide=] the [=portal host object=] of |portalBrowsingContext|.
 
+        1. Let |targetRealm| be |successorWindow|'s [=environment settings object/realm=].
+
+        1. Let |dataClone| be [$StructuredDeserialize$](|serializedData|, |targetRealm|).
+
+            If this throws an exception, catch it, and let |dataClone| be null instead.
+
         1. Let |event| be the result of [=creating an event=] using {{PortalActivateEvent}}.
 
         1. Initialize |event|'s {{Event/type}} attribute to {{Window/portalactivate!!event}}.
+
+        1. Initialize |event|'s {{PortalActivateEvent/data}} attribute to |dataClone|.
 
         1. Set |event|'s [=PortalActivateEvent/predecessor browsing context=] to |predecessorBrowsingContext|.
 
@@ -107,6 +116,11 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
 
         1. [=Queue a task=] to [=complete portal activation=].
   </section>
+
+  <div class="issue">
+    In the case that structured deserialization throws, it may be useful to do something else to indicate it,
+    rather than simply providing null data.
+  </div>
 
   <div class="issue">
     We need to specify how the [=session history=] of each browsing context is
@@ -166,7 +180,7 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
       };
 
       dictionary PortalActivateOptions {
-          any data;
+          any data = null;
       };
   </xmp>
 
@@ -192,10 +206,13 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
 
         If no such context exists, throw an "{{InvalidStateError}}" {{DOMException}}.
 
+    1. Let |serializedData| be [$StructuredSerialize$](|options|["{{PortalActivateOptions/data}}"]).
+        Rethrow any exceptions.
+
     1. Let |promise| be a new [=promise=].
 
     1. Run the steps to [=activate a portal browsing context|activate=] |portalBrowsingContext|
-        in place of |predecessorBrowsingContext|.
+        in place of |predecessorBrowsingContext| with data |serializedData|.
 
         To [=complete portal activation=], run these steps:
 
@@ -435,6 +452,7 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
 
   <xmp class="idl">
       interface PortalActivateEvent : Event {
+          readonly attribute any data;
           HTMLPortalElement adoptPredecessor(Document document);
       };
   </xmp>

--- a/index.bs
+++ b/index.bs
@@ -161,8 +161,12 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
       [HTMLConstructor]
       interface HTMLPortalElement : HTMLElement {
           [CEReactions] attribute USVString src;
-          [NewObject] Promise<void> activate();
+          [NewObject] Promise<void> activate(optional PortalActivateOptions options);
           void postMessage(any message, DOMString targetOrigin, optional sequence<object> transfer = []);
+      };
+
+      dictionary PortalActivateOptions {
+          any data;
       };
   </xmp>
 
@@ -177,7 +181,7 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
   * <dfn>complete portal activation</dfn>
 
   <section algorithm="htmlportalelement-activate">
-    The <dfn method for="HTMLPortalElement"><code>activate()</code></dfn> method *must* run these steps:
+    The <dfn method for="HTMLPortalElement"><code>activate(|options|)</code></dfn> method *must* run these steps:
 
     1. Let |portalBrowsingContext| be the [=guest browsing context=] of the [=context object=].
 

--- a/index.bs
+++ b/index.bs
@@ -80,8 +80,8 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
 
   <section algorithm="portal-browsing-context-activate">
     To <dfn>activate a portal browsing context</dfn> |portalBrowsingContext| in
-    place of |predecessorBrowsingContext| with data |serializedData|, run the
-    following steps [=in parallel=]:
+    place of |predecessorBrowsingContext| with data |serializeWithTransferResult|,
+    run the following steps [=in parallel=]:
 
     1. Let |successorWindow| be |portalBrowsingContext|'s associated {{WindowProxy}}'s \[[Window]] internal slot value.
 
@@ -97,7 +97,7 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
 
         1. Let |targetRealm| be |successorWindow|'s [=environment settings object/realm=].
 
-        1. Let |dataClone| be [$StructuredDeserialize$](|serializedData|, |targetRealm|).
+        1. Let |dataClone| be [$StructuredDeserializeWithTransfer$](|serializeWithTransferResult|, |targetRealm|).
 
             If this throws an exception, catch it, and let |dataClone| be null instead.
 
@@ -181,6 +181,7 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
 
       dictionary PortalActivateOptions {
           any data = null;
+          sequence<object> transfer = [];
       };
   </xmp>
 
@@ -206,13 +207,15 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
 
         If no such context exists, throw an "{{InvalidStateError}}" {{DOMException}}.
 
-    1. Let |serializedData| be [$StructuredSerialize$](|options|["{{PortalActivateOptions/data}}"]).
+    1. Let |serializeWithTransferResult| be
+        [$StructuredSerializeWithTransfer$](|options|["{{PortalActivateOptions/data}}"],
+        |options|["{{PortalActivateOptions/transfer}}"]).
         Rethrow any exceptions.
 
     1. Let |promise| be a new [=promise=].
 
     1. Run the steps to [=activate a portal browsing context|activate=] |portalBrowsingContext|
-        in place of |predecessorBrowsingContext| with data |serializedData|.
+        in place of |predecessorBrowsingContext| with data |serializeWithTransferResult|.
 
         To [=complete portal activation=], run these steps:
 

--- a/index.html
+++ b/index.html
@@ -1213,7 +1213,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 6abc9f98f620481a5031cd9b44944d60af9b79b9" name="generator">
   <link href="https://kenjibaheux.github.io/portals/" rel="canonical">
-  <meta content="e651d3e5e8f0ebc2adeca7c60f82efbc79f0498d" name="document-revision">
+  <meta content="2b646be86e73cc71104eef5efad7f0ae2de73b1a" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1549,7 +1549,8 @@ Parts of this work may be from another specification document.  If so, those par
     context, but rather that it will be presented only through a <a data-link-type="dfn" href="#host" id="ref-for-host">host</a> element. </p>
     <section class="algorithm" data-algorithm="portal-browsing-context-activate">
       To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="activate-a-portal-browsing-context">activate a portal browsing context</dfn> <var>portalBrowsingContext</var> in
-    place of <var>predecessorBrowsingContext</var>, run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel">in parallel</a>: 
+    place of <var>predecessorBrowsingContext</var> with data <var>serializedData</var>, run the
+    following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel">in parallel</a>: 
      <ol>
       <li data-md="">
        <p>Let <var>successorWindow</var> be <var>portalBrowsingContext</var>’s associated <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/window-object.html#windowproxy" id="ref-for-windowproxy">WindowProxy</a></code>'s [[Window]] internal slot value.</p>
@@ -1562,9 +1563,16 @@ Parts of this work may be from another specification document.  If so, those par
         <li data-md="">
          <p><a data-link-type="dfn" href="#portalhost-hidden" id="ref-for-portalhost-hidden">Hide</a> the <a data-link-type="dfn" href="#portal-host-object" id="ref-for-portal-host-object">portal host object</a> of <var>portalBrowsingContext</var>.</p>
         <li data-md="">
+         <p>Let <var>targetRealm</var> be <var>successorWindow</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm" id="ref-for-environment-settings-object&apos;s-realm">realm</a>.</p>
+        <li data-md="">
+         <p>Let <var>dataClone</var> be <a data-link-type="abstract-op" href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize" id="ref-for-structureddeserialize">StructuredDeserialize</a>(<var>serializedData</var>, <var>targetRealm</var>).</p>
+         <p>If this throws an exception, catch it, and let <var>dataClone</var> be null instead.</p>
+        <li data-md="">
          <p>Let <var>event</var> be the result of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-create" id="ref-for-concept-event-create">creating an event</a> using <code class="idl"><a data-link-type="idl" href="#portalactivateevent" id="ref-for-portalactivateevent">PortalActivateEvent</a></code>.</p>
         <li data-md="">
          <p>Initialize <var>event</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-type" id="ref-for-dom-event-type">type</a></code> attribute to <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-window-portalactivate" id="ref-for-eventdef-window-portalactivate">portalactivate</a></code>.</p>
+        <li data-md="">
+         <p>Initialize <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-portalactivateevent-data" id="ref-for-dom-portalactivateevent-data">data</a></code> attribute to <var>dataClone</var>.</p>
         <li data-md="">
          <p>Set <var>event</var>’s <a data-link-type="dfn" href="#portalactivateevent-predecessor-browsing-context" id="ref-for-portalactivateevent-predecessor-browsing-context">predecessor browsing context</a> to <var>predecessorBrowsingContext</var>.</p>
         <li data-md="">
@@ -1577,6 +1585,8 @@ The user agent <em>should not</em> <a data-link-type="dfn" href="https://html.sp
        </ol>
      </ol>
     </section>
+    <div class="issue" id="issue-b49e4903"><a class="self-link" href="#issue-b49e4903"></a> In the case that structured deserialization throws, it may be useful to do something else to indicate it,
+    rather than simply providing null data. </div>
     <div class="issue" id="issue-0d72b101"><a class="self-link" href="#issue-0d72b101"></a> We need to specify how the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/history.html#session-history" id="ref-for-session-history">session history</a> of each browsing context is
     affected by activation, and supply non-normative text that explains how
     these histories are expected to be presented to the user. </div>
@@ -1619,7 +1629,7 @@ The user agent <em>should not</em> <a data-link-type="dfn" href="https://html.sp
 };
 
 <span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-portalactivateoptions"><code>PortalActivateOptions</code></dfn> {
-    <span class="kt">any</span> <dfn class="nv idl-code" data-dfn-for="PortalActivateOptions" data-dfn-type="dict-member" data-export="" data-type="any " id="dom-portalactivateoptions-data"><code>data</code><a class="self-link" href="#dom-portalactivateoptions-data"></a></dfn>;
+    <span class="kt">any</span> <dfn class="nv dfn-paneled idl-code" data-default="null" data-dfn-for="PortalActivateOptions" data-dfn-type="dict-member" data-export="" data-type="any " id="dom-portalactivateoptions-data"><code>data</code></dfn> = <span class="kt">null</span>;
 };
 </pre>
     <div class="issue" id="issue-ca552fc8"><a class="self-link" href="#issue-ca552fc8"></a> This should also include a <code>PostMessageOptions</code> dictionary overload, to reflect the changes due to the <a href="https://github.com/dtapuska/useractivation">user activation proposal</a>. </div>
@@ -1639,9 +1649,12 @@ The user agent <em>should not</em> <a data-link-type="dfn" href="https://html.sp
        <p>Let <var>predecessorBrowsingContext</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-bc" id="ref-for-concept-document-bc">browsing context</a> of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object" id="ref-for-context-object①">context object</a>'s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document">document</a>.</p>
        <p>If no such context exists, throw an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror" id="ref-for-invalidstateerror①">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException①">DOMException</a></code>.</p>
       <li data-md="">
+       <p>Let <var>serializedData</var> be <a data-link-type="abstract-op" href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserialize" id="ref-for-structuredserialize">StructuredSerialize</a>(<var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-portalactivateoptions-data" id="ref-for-dom-portalactivateoptions-data">data</a></code>"]).
+Rethrow any exceptions.</p>
+      <li data-md="">
        <p>Let <var>promise</var> be a new <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects" id="ref-for-sec-promise-objects">promise</a>.</p>
       <li data-md="">
-       <p>Run the steps to <a data-link-type="dfn" href="#activate-a-portal-browsing-context" id="ref-for-activate-a-portal-browsing-context">activate</a> <var>portalBrowsingContext</var> in place of <var>predecessorBrowsingContext</var>.</p>
+       <p>Run the steps to <a data-link-type="dfn" href="#activate-a-portal-browsing-context" id="ref-for-activate-a-portal-browsing-context">activate</a> <var>portalBrowsingContext</var> in place of <var>predecessorBrowsingContext</var> with data <var>serializedData</var>.</p>
        <p>To <a data-link-type="dfn" href="#complete-portal-activation" id="ref-for-complete-portal-activation②">complete portal activation</a>, run these steps:</p>
        <ol>
         <li data-md="">
@@ -1677,7 +1690,7 @@ abort these steps.</p>
         <li data-md="">
          <p>Let <var>portalHost</var> be the <var>targetWindow</var>’s <a data-link-type="dfn" href="#portal-host-object" id="ref-for-portal-host-object②">portal host object</a>.</p>
         <li data-md="">
-         <p>Let <var>targetRealm</var> be the <var>targetWindow</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm" id="ref-for-environment-settings-object&apos;s-realm">realm</a>.</p>
+         <p>Let <var>targetRealm</var> be the <var>targetWindow</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm" id="ref-for-environment-settings-object&apos;s-realm①">realm</a>.</p>
         <li data-md="">
          <p>Let <var>deserializeRecord</var> be <a data-link-type="abstract-op" href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserializewithtransfer" id="ref-for-structureddeserializewithtransfer">StructuredDeserializeWithTransfer</a>(<var>serializeWithTransferResult</var>, <var>targetRealm</var>).</p>
          <p>If this throws an exception, catch it, <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire" id="ref-for-concept-event-fire">fire an event</a> named <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-portalhost-messageerror" id="ref-for-eventdef-portalhost-messageerror">messageerror</a></code> at <var>portalHost</var> using <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/comms.html#messageevent" id="ref-for-messageevent">MessageEvent</a></code> with the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-origin" id="ref-for-dom-messageevent-origin">origin</a></code> attribute initialized to <var>origin</var> and the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-source" id="ref-for-dom-messageevent-source">source</a></code> attribute initialized to <var>portalHost</var>,
@@ -1704,7 +1717,7 @@ initialized to <var>messageClone</var>, and the <code class="idl"><a data-link-t
        <p>If <var>targetOrigin</var> is not a single literal U+002A ASTERISK character
 (*) and <var>settings</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin①">origin</a> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-origin" id="ref-for-same-origin①">same origin</a> with <var>targetOrigin</var>, then abort these steps.</p>
       <li data-md="">
-       <p>Let <var>targetRealm</var> be <var>settings</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm" id="ref-for-environment-settings-object&apos;s-realm①">realm</a>.</p>
+       <p>Let <var>targetRealm</var> be <var>settings</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm" id="ref-for-environment-settings-object&apos;s-realm②">realm</a>.</p>
       <li data-md="">
        <p>Let <var>deserializeRecord</var> be <a data-link-type="abstract-op" href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserializewithtransfer" id="ref-for-structureddeserializewithtransfer①">StructuredDeserializeWithTransfer</a>(<var>serializeWithTransferResult</var>, <var>targetRealm</var>).</p>
        <p>If this throws an exception, catch it, <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire" id="ref-for-concept-event-fire②">fire an event</a> named <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-htmlportalelement-messageerror" id="ref-for-eventdef-htmlportalelement-messageerror">messageerror</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object" id="ref-for-context-object⑤">context object</a> using <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/comms.html#messageevent" id="ref-for-messageevent②">MessageEvent</a></code> with the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-origin" id="ref-for-dom-messageevent-origin②">origin</a></code> attribute initialized to <var>origin</var> and the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-source" id="ref-for-dom-messageevent-source②">source</a></code> attribute initialized to the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object" id="ref-for-context-object⑥">context object</a>,</p>
@@ -1840,6 +1853,7 @@ throw an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.
     </table>
     <h3 class="heading settled" data-level="3.3" id="the-portalactivateevent-interface"><span class="secno">3.3. </span><span class="content">The <code>PortalActivateEvent</code> interface</span><a class="self-link" href="#the-portalactivateevent-interface"></a></h3>
 <pre class="idl highlight def"><span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="portalactivateevent"><code>PortalActivateEvent</code></dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event" id="ref-for-event">Event</a> {
+    <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">any</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="PortalActivateEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="any" id="dom-portalactivateevent-data"><code>data</code></dfn>;
     <a class="n" data-link-type="idl-name" href="#htmlportalelement" id="ref-for-htmlportalelement③">HTMLPortalElement</a> <a class="nv idl-code" data-link-type="method" href="#dom-portalactivateevent-adoptpredecessor" id="ref-for-dom-portalactivateevent-adoptpredecessor">adoptPredecessor</a>(<a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#document" id="ref-for-document">Document</a> <dfn class="nv idl-code" data-dfn-for="PortalActivateEvent/adoptPredecessor(document)" data-dfn-type="argument" data-export="" id="dom-portalactivateevent-adoptpredecessor-document-document"><code>document</code><a class="self-link" href="#dom-portalactivateevent-adoptpredecessor-document-document"></a></dfn>);
 };
 </pre>
@@ -2057,7 +2071,12 @@ throw an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.
    <li><a href="#adopt-the-predecessor-browsing-context">adopt the predecessor browsing context</a><span>, in §2</span>
    <li><a href="#htmlportalelement-close-a-portal-element">close a portal element</a><span>, in §3.1</span>
    <li><a href="#complete-portal-activation">complete portal activation</a><span>, in §3.1</span>
-   <li><a href="#dom-portalactivateoptions-data">data</a><span>, in §3.1</span>
+   <li>
+    data
+    <ul>
+     <li><a href="#dom-portalactivateevent-data">attribute for PortalActivateEvent</a><span>, in §3.3</span>
+     <li><a href="#dom-portalactivateoptions-data">dict-member for PortalActivateOptions</a><span>, in §3.1</span>
+    </ul>
    <li><a href="#portalhost-exposed">exposed</a><span>, in §3.2</span>
    <li><a href="#htmlportalelement-guest-browsing-context">guest browsing context</a><span>, in §3.1</span>
    <li><a href="#portalhost-hidden">hidden</a><span>, in §3.2</span>
@@ -2238,10 +2257,22 @@ throw an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.
     <li><a href="#ref-for-messageport②">3.4. Miscellaneous extensions</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-structureddeserialize">
+   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize">https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-structureddeserialize">2. Concepts</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-structureddeserializewithtransfer">
    <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserializewithtransfer">https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserializewithtransfer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structureddeserializewithtransfer">3.1. The portal element</a> <a href="#ref-for-structureddeserializewithtransfer①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-structuredserialize">
+   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserialize">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserialize</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-structuredserialize">3.1. The portal element</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-structuredserializewithtransfer">
@@ -2377,7 +2408,8 @@ throw an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.
   <aside class="dfn-panel" data-for="term-for-environment-settings-object&apos;s-realm">
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object's-realm</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-environment-settings-object&apos;s-realm">3.1. The portal element</a> <a href="#ref-for-environment-settings-object&apos;s-realm①">(2)</a>
+    <li><a href="#ref-for-environment-settings-object&apos;s-realm">2. Concepts</a>
+    <li><a href="#ref-for-environment-settings-object&apos;s-realm①">3.1. The portal element</a> <a href="#ref-for-environment-settings-object&apos;s-realm②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-refused-to-allow-the-document-to-be-unloaded">
@@ -2562,7 +2594,9 @@ throw an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.
      <li><span class="dfn-paneled" id="term-for-htmlelement" style="color:initial">HTMLElement</span>
      <li><span class="dfn-paneled" id="term-for-messageevent" style="color:initial">MessageEvent</span>
      <li><span class="dfn-paneled" id="term-for-messageport" style="color:initial">MessagePort</span>
+     <li><span class="dfn-paneled" id="term-for-structureddeserialize" style="color:initial">StructuredDeserialize</span>
      <li><span class="dfn-paneled" id="term-for-structureddeserializewithtransfer" style="color:initial">StructuredDeserializeWithTransfer</span>
+     <li><span class="dfn-paneled" id="term-for-structuredserialize" style="color:initial">StructuredSerialize</span>
      <li><span class="dfn-paneled" id="term-for-structuredserializewithtransfer" style="color:initial">StructuredSerializeWithTransfer</span>
      <li><span class="dfn-paneled" id="term-for-window" style="color:initial">Window</span>
      <li><span class="dfn-paneled" id="term-for-windowproxy" style="color:initial">WindowProxy</span>
@@ -2662,7 +2696,7 @@ throw an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.
 };
 
 <span class="kt">dictionary</span> <a class="nv" href="#dictdef-portalactivateoptions"><code>PortalActivateOptions</code></a> {
-    <span class="kt">any</span> <a class="nv" data-type="any " href="#dom-portalactivateoptions-data"><code>data</code></a>;
+    <span class="kt">any</span> <a class="nv" data-default="null" data-type="any " href="#dom-portalactivateoptions-data"><code>data</code></a> = <span class="kt">null</span>;
 };
 
 <span class="kt">interface</span> <a class="nv" href="#portalhost"><code>PortalHost</code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget①">EventTarget</a> {
@@ -2670,6 +2704,7 @@ throw an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.
 };
 
 <span class="kt">interface</span> <a class="nv" href="#portalactivateevent"><code>PortalActivateEvent</code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event" id="ref-for-event①">Event</a> {
+    <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">any</span> <a class="nv" data-readonly="" data-type="any" href="#dom-portalactivateevent-data"><code>data</code></a>;
     <a class="n" data-link-type="idl-name" href="#htmlportalelement" id="ref-for-htmlportalelement③①">HTMLPortalElement</a> <a class="nv idl-code" data-link-type="method" href="#dom-portalactivateevent-adoptpredecessor" id="ref-for-dom-portalactivateevent-adoptpredecessor①">adoptPredecessor</a>(<a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①">Document</a> <a class="nv" href="#dom-portalactivateevent-adoptpredecessor-document-document"><code>document</code></a>);
 };
 
@@ -2682,6 +2717,8 @@ throw an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.
 </pre>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">
+   <div class="issue"> In the case that structured deserialization throws, it may be useful to do something else to indicate it,
+    rather than simply providing null data. <a href="#issue-b49e4903"> ↵ </a></div>
    <div class="issue"> We need to specify how the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/history.html#session-history">session history</a> of each browsing context is
     affected by activation, and supply non-normative text that explains how
     these histories are expected to be presented to the user. <a href="#issue-0d72b101"> ↵ </a></div>
@@ -2761,6 +2798,12 @@ throw an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.
    <b><a href="#dictdef-portalactivateoptions">#dictdef-portalactivateoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-portalactivateoptions">3.1. The portal element</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-portalactivateoptions-data">
+   <b><a href="#dom-portalactivateoptions-data">#dom-portalactivateoptions-data</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-portalactivateoptions-data">3.1. The portal element</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="complete-portal-activation">
@@ -2863,6 +2906,12 @@ throw an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.
     <li><a href="#ref-for-portalactivateevent">2. Concepts</a>
     <li><a href="#ref-for-portalactivateevent①">3.3. The PortalActivateEvent interface</a>
     <li><a href="#ref-for-portalactivateevent②">3.4. Miscellaneous extensions</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-portalactivateevent-data">
+   <b><a href="#dom-portalactivateevent-data">#dom-portalactivateevent-data</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-portalactivateevent-data">2. Concepts</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="portalactivateevent-predecessor-browsing-context">

--- a/index.html
+++ b/index.html
@@ -1213,7 +1213,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 6abc9f98f620481a5031cd9b44944d60af9b79b9" name="generator">
   <link href="https://kenjibaheux.github.io/portals/" rel="canonical">
-  <meta content="5bd086f0c1a13823629f28a1352c4173a694a476" name="document-revision">
+  <meta content="e651d3e5e8f0ebc2adeca7c60f82efbc79f0498d" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1471,7 +1471,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Portals</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">A Collection of Interesting Ideas, <time class="dt-updated" datetime="2018-09-19">19 September 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">A Collection of Interesting Ideas, <time class="dt-updated" datetime="2018-11-20">20 November 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1487,7 +1487,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
    <div data-fill-with="warning"></div>
    <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a> To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 19 September 2018,
+In addition, as of 20 November 2018,
 the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
 Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document. </p>
@@ -1614,8 +1614,12 @@ The user agent <em>should not</em> <a data-link-type="dfn" href="https://html.sp
 <pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/dom.html#htmlconstructor" id="ref-for-htmlconstructor">HTMLConstructor</a>]
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="htmlportalelement"><code>HTMLPortalElement</code></dfn> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement" id="ref-for-htmlelement">HTMLElement</a> {
     [<a class="nv idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions">CEReactions</a>] <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString"><span class="kt">USVString</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="HTMLPortalElement" data-dfn-type="attribute" data-export="" data-type="USVString" id="dom-htmlportalelement-src"><code>src</code></dfn>;
-    [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject" id="ref-for-NewObject">NewObject</a>] <span class="kt">Promise</span>&lt;<span class="kt">void</span>> <a class="nv idl-code" data-link-type="method" href="#dom-htmlportalelement-activate" id="ref-for-dom-htmlportalelement-activate①">activate</a>();
+    [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject" id="ref-for-NewObject">NewObject</a>] <span class="kt">Promise</span>&lt;<span class="kt">void</span>> <a class="nv idl-code" data-link-type="method" href="#dom-htmlportalelement-activate" id="ref-for-dom-htmlportalelement-activate①">activate</a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-portalactivateoptions" id="ref-for-dictdef-portalactivateoptions">PortalActivateOptions</a> <dfn class="nv idl-code" data-dfn-for="HTMLPortalElement/activate(options), HTMLPortalElement/activate()" data-dfn-type="argument" data-export="" id="dom-htmlportalelement-activate-options-options"><code>options</code><a class="self-link" href="#dom-htmlportalelement-activate-options-options"></a></dfn>);
     <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-htmlportalelement-postmessage" id="ref-for-dom-htmlportalelement-postmessage">postMessage</a>(<span class="kt">any</span> <dfn class="nv idl-code" data-dfn-for="HTMLPortalElement/postMessage(message, targetOrigin, transfer), HTMLPortalElement/postMessage(message, targetOrigin)" data-dfn-type="argument" data-export="" id="dom-htmlportalelement-postmessage-message-targetorigin-transfer-message"><code>message</code><a class="self-link" href="#dom-htmlportalelement-postmessage-message-targetorigin-transfer-message"></a></dfn>, <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="HTMLPortalElement/postMessage(message, targetOrigin, transfer), HTMLPortalElement/postMessage(message, targetOrigin)" data-dfn-type="argument" data-export="" id="dom-htmlportalelement-postmessage-message-targetorigin-transfer-targetorigin"><code>targetOrigin</code><a class="self-link" href="#dom-htmlportalelement-postmessage-message-targetorigin-transfer-targetorigin"></a></dfn>, <span class="kt">optional</span> <span class="kt">sequence</span>&lt;<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-object" id="ref-for-idl-object"><span class="kt">object</span></a>> <dfn class="nv idl-code" data-dfn-for="HTMLPortalElement/postMessage(message, targetOrigin, transfer), HTMLPortalElement/postMessage(message, targetOrigin)" data-dfn-type="argument" data-export="" id="dom-htmlportalelement-postmessage-message-targetorigin-transfer-transfer"><code>transfer</code><a class="self-link" href="#dom-htmlportalelement-postmessage-message-targetorigin-transfer-transfer"></a></dfn> = []);
+};
+
+<span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-portalactivateoptions"><code>PortalActivateOptions</code></dfn> {
+    <span class="kt">any</span> <dfn class="nv idl-code" data-dfn-for="PortalActivateOptions" data-dfn-type="dict-member" data-export="" data-type="any " id="dom-portalactivateoptions-data"><code>data</code><a class="self-link" href="#dom-portalactivateoptions-data"></a></dfn>;
 };
 </pre>
     <div class="issue" id="issue-ca552fc8"><a class="self-link" href="#issue-ca552fc8"></a> This should also include a <code>PostMessageOptions</code> dictionary overload, to reflect the changes due to the <a href="https://github.com/dtapuska/useractivation">user activation proposal</a>. </div>
@@ -1626,7 +1630,7 @@ The user agent <em>should not</em> <a data-link-type="dfn" href="https://html.sp
       <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="complete-portal-activation">complete portal activation</dfn></p>
     </ul>
     <section class="algorithm" data-algorithm="htmlportalelement-activate">
-      The <dfn class="dfn-paneled idl-code" data-dfn-for="HTMLPortalElement" data-dfn-type="method" data-export="" id="dom-htmlportalelement-activate"><code>activate()</code></dfn> method <em>must</em> run these steps: 
+      The <dfn class="dfn-paneled idl-code" data-dfn-for="HTMLPortalElement" data-dfn-type="method" data-export="" data-lt="activate(options)|activate()" id="dom-htmlportalelement-activate"><code>activate(<var>options</var>)</code></dfn> method <em>must</em> run these steps: 
      <ol>
       <li data-md="">
        <p>Let <var>portalBrowsingContext</var> be the <a data-link-type="dfn" href="#htmlportalelement-guest-browsing-context" id="ref-for-htmlportalelement-guest-browsing-context②">guest browsing context</a> of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object" id="ref-for-context-object">context object</a>.</p>
@@ -2048,10 +2052,12 @@ throw an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.
    <li><a href="#accept-a-message-posted-to-the-host">accept a message posted to the host</a><span>, in §2</span>
    <li><a href="#dom-htmlportalelement-activate">activate()</a><span>, in §3.1</span>
    <li><a href="#activate-a-portal-browsing-context">activate a portal browsing context</a><span>, in §2</span>
+   <li><a href="#dom-htmlportalelement-activate">activate(options)</a><span>, in §3.1</span>
    <li><a href="#dom-portalactivateevent-adoptpredecessor">adoptPredecessor(document)</a><span>, in §3.3</span>
    <li><a href="#adopt-the-predecessor-browsing-context">adopt the predecessor browsing context</a><span>, in §2</span>
    <li><a href="#htmlportalelement-close-a-portal-element">close a portal element</a><span>, in §3.1</span>
    <li><a href="#complete-portal-activation">complete portal activation</a><span>, in §3.1</span>
+   <li><a href="#dom-portalactivateoptions-data">data</a><span>, in §3.1</span>
    <li><a href="#portalhost-exposed">exposed</a><span>, in §3.2</span>
    <li><a href="#htmlportalelement-guest-browsing-context">guest browsing context</a><span>, in §3.1</span>
    <li><a href="#portalhost-hidden">hidden</a><span>, in §3.2</span>
@@ -2073,6 +2079,7 @@ throw an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.
    <li><a href="#elementdef-portal">portal</a><span>, in §3.1</span>
    <li><a href="#eventdef-window-portalactivate">portalactivate</a><span>, in §3.4</span>
    <li><a href="#portalactivateevent">PortalActivateEvent</a><span>, in §3.3</span>
+   <li><a href="#dictdef-portalactivateoptions">PortalActivateOptions</a><span>, in §3.1</span>
    <li><a href="#portal-browsing-context">portal browsing context</a><span>, in §2</span>
    <li><a href="#dom-window-portalhost">portalHost</a><span>, in §3.4</span>
    <li><a href="#portalhost">PortalHost</a><span>, in §3.2</span>
@@ -2650,8 +2657,12 @@ throw an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.
 <pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/dom.html#htmlconstructor" id="ref-for-htmlconstructor①">HTMLConstructor</a>]
 <span class="kt">interface</span> <a class="nv" href="#htmlportalelement"><code>HTMLPortalElement</code></a> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement" id="ref-for-htmlelement①">HTMLElement</a> {
     [<a class="nv idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①">CEReactions</a>] <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①"><span class="kt">USVString</span></a> <a class="nv" data-type="USVString" href="#dom-htmlportalelement-src"><code>src</code></a>;
-    [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject" id="ref-for-NewObject①">NewObject</a>] <span class="kt">Promise</span>&lt;<span class="kt">void</span>> <a class="nv idl-code" data-link-type="method" href="#dom-htmlportalelement-activate" id="ref-for-dom-htmlportalelement-activate①①">activate</a>();
+    [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject" id="ref-for-NewObject①">NewObject</a>] <span class="kt">Promise</span>&lt;<span class="kt">void</span>> <a class="nv idl-code" data-link-type="method" href="#dom-htmlportalelement-activate" id="ref-for-dom-htmlportalelement-activate①①">activate</a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-portalactivateoptions" id="ref-for-dictdef-portalactivateoptions①">PortalActivateOptions</a> <a class="nv" href="#dom-htmlportalelement-activate-options-options"><code>options</code></a>);
     <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-htmlportalelement-postmessage" id="ref-for-dom-htmlportalelement-postmessage①">postMessage</a>(<span class="kt">any</span> <a class="nv" href="#dom-htmlportalelement-postmessage-message-targetorigin-transfer-message"><code>message</code></a>, <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-htmlportalelement-postmessage-message-targetorigin-transfer-targetorigin"><code>targetOrigin</code></a>, <span class="kt">optional</span> <span class="kt">sequence</span>&lt;<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-object" id="ref-for-idl-object②"><span class="kt">object</span></a>> <a class="nv" href="#dom-htmlportalelement-postmessage-message-targetorigin-transfer-transfer"><code>transfer</code></a> = []);
+};
+
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-portalactivateoptions"><code>PortalActivateOptions</code></a> {
+    <span class="kt">any</span> <a class="nv" data-type="any " href="#dom-portalactivateoptions-data"><code>data</code></a>;
 };
 
 <span class="kt">interface</span> <a class="nv" href="#portalhost"><code>PortalHost</code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget①">EventTarget</a> {
@@ -2744,6 +2755,12 @@ throw an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.
    <b><a href="#dom-htmlportalelement-src">#dom-htmlportalelement-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlportalelement-src">3.1. The portal element</a> <a href="#ref-for-dom-htmlportalelement-src①">(2)</a> <a href="#ref-for-dom-htmlportalelement-src②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-portalactivateoptions">
+   <b><a href="#dictdef-portalactivateoptions">#dictdef-portalactivateoptions</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-portalactivateoptions">3.1. The portal element</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="complete-portal-activation">

--- a/index.html
+++ b/index.html
@@ -1213,7 +1213,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 6abc9f98f620481a5031cd9b44944d60af9b79b9" name="generator">
   <link href="https://kenjibaheux.github.io/portals/" rel="canonical">
-  <meta content="2b646be86e73cc71104eef5efad7f0ae2de73b1a" name="document-revision">
+  <meta content="94076289932b01f801f2c9bc32ec40adfbf956e8" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1549,8 +1549,8 @@ Parts of this work may be from another specification document.  If so, those par
     context, but rather that it will be presented only through a <a data-link-type="dfn" href="#host" id="ref-for-host">host</a> element. </p>
     <section class="algorithm" data-algorithm="portal-browsing-context-activate">
       To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="activate-a-portal-browsing-context">activate a portal browsing context</dfn> <var>portalBrowsingContext</var> in
-    place of <var>predecessorBrowsingContext</var> with data <var>serializedData</var>, run the
-    following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel">in parallel</a>: 
+    place of <var>predecessorBrowsingContext</var> with data <var>serializeWithTransferResult</var>,
+    run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel">in parallel</a>: 
      <ol>
       <li data-md="">
        <p>Let <var>successorWindow</var> be <var>portalBrowsingContext</var>’s associated <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/window-object.html#windowproxy" id="ref-for-windowproxy">WindowProxy</a></code>'s [[Window]] internal slot value.</p>
@@ -1565,7 +1565,7 @@ Parts of this work may be from another specification document.  If so, those par
         <li data-md="">
          <p>Let <var>targetRealm</var> be <var>successorWindow</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm" id="ref-for-environment-settings-object&apos;s-realm">realm</a>.</p>
         <li data-md="">
-         <p>Let <var>dataClone</var> be <a data-link-type="abstract-op" href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize" id="ref-for-structureddeserialize">StructuredDeserialize</a>(<var>serializedData</var>, <var>targetRealm</var>).</p>
+         <p>Let <var>dataClone</var> be <a data-link-type="abstract-op" href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserializewithtransfer" id="ref-for-structureddeserializewithtransfer">StructuredDeserializeWithTransfer</a>(<var>serializeWithTransferResult</var>, <var>targetRealm</var>).</p>
          <p>If this throws an exception, catch it, and let <var>dataClone</var> be null instead.</p>
         <li data-md="">
          <p>Let <var>event</var> be the result of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-create" id="ref-for-concept-event-create">creating an event</a> using <code class="idl"><a data-link-type="idl" href="#portalactivateevent" id="ref-for-portalactivateevent">PortalActivateEvent</a></code>.</p>
@@ -1630,6 +1630,7 @@ The user agent <em>should not</em> <a data-link-type="dfn" href="https://html.sp
 
 <span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-portalactivateoptions"><code>PortalActivateOptions</code></dfn> {
     <span class="kt">any</span> <dfn class="nv dfn-paneled idl-code" data-default="null" data-dfn-for="PortalActivateOptions" data-dfn-type="dict-member" data-export="" data-type="any " id="dom-portalactivateoptions-data"><code>data</code></dfn> = <span class="kt">null</span>;
+    <span class="kt">sequence</span>&lt;<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-object" id="ref-for-idl-object①"><span class="kt">object</span></a>> <dfn class="nv dfn-paneled idl-code" data-default="None" data-dfn-for="PortalActivateOptions" data-dfn-type="dict-member" data-export="" data-type="sequence<object> " id="dom-portalactivateoptions-transfer"><code>transfer</code></dfn> = [];
 };
 </pre>
     <div class="issue" id="issue-ca552fc8"><a class="self-link" href="#issue-ca552fc8"></a> This should also include a <code>PostMessageOptions</code> dictionary overload, to reflect the changes due to the <a href="https://github.com/dtapuska/useractivation">user activation proposal</a>. </div>
@@ -1649,12 +1650,12 @@ The user agent <em>should not</em> <a data-link-type="dfn" href="https://html.sp
        <p>Let <var>predecessorBrowsingContext</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-bc" id="ref-for-concept-document-bc">browsing context</a> of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object" id="ref-for-context-object①">context object</a>'s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document">document</a>.</p>
        <p>If no such context exists, throw an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror" id="ref-for-invalidstateerror①">InvalidStateError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException①">DOMException</a></code>.</p>
       <li data-md="">
-       <p>Let <var>serializedData</var> be <a data-link-type="abstract-op" href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserialize" id="ref-for-structuredserialize">StructuredSerialize</a>(<var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-portalactivateoptions-data" id="ref-for-dom-portalactivateoptions-data">data</a></code>"]).
+       <p>Let <var>serializeWithTransferResult</var> be <a data-link-type="abstract-op" href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer" id="ref-for-structuredserializewithtransfer">StructuredSerializeWithTransfer</a>(<var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-portalactivateoptions-data" id="ref-for-dom-portalactivateoptions-data">data</a></code>"], <var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-portalactivateoptions-transfer" id="ref-for-dom-portalactivateoptions-transfer">transfer</a></code>"]).
 Rethrow any exceptions.</p>
       <li data-md="">
        <p>Let <var>promise</var> be a new <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects" id="ref-for-sec-promise-objects">promise</a>.</p>
       <li data-md="">
-       <p>Run the steps to <a data-link-type="dfn" href="#activate-a-portal-browsing-context" id="ref-for-activate-a-portal-browsing-context">activate</a> <var>portalBrowsingContext</var> in place of <var>predecessorBrowsingContext</var> with data <var>serializedData</var>.</p>
+       <p>Run the steps to <a data-link-type="dfn" href="#activate-a-portal-browsing-context" id="ref-for-activate-a-portal-browsing-context">activate</a> <var>portalBrowsingContext</var> in place of <var>predecessorBrowsingContext</var> with data <var>serializeWithTransferResult</var>.</p>
        <p>To <a data-link-type="dfn" href="#complete-portal-activation" id="ref-for-complete-portal-activation②">complete portal activation</a>, run these steps:</p>
        <ol>
         <li data-md="">
@@ -1677,7 +1678,7 @@ Rethrow any exceptions.</p>
       <li data-md="">
        <p>If <var>targetOrigin</var> is a single U+002F SOLIDUS character (/), then set <var>targetOrigin</var> to the <a href="https://html.spec.whatwg.org/multipage/#concept-settings-object-origin">origin</a> of <var>settings</var>.</p>
       <li data-md="">
-       <p>Let <var>serializeWithTransferResult</var> be <a data-link-type="abstract-op" href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer" id="ref-for-structuredserializewithtransfer">StructuredSerializeWithTransfer</a>(<var>message</var>, <var>transfer</var>). Rethrow any exceptions.</p>
+       <p>Let <var>serializeWithTransferResult</var> be <a data-link-type="abstract-op" href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer" id="ref-for-structuredserializewithtransfer①">StructuredSerializeWithTransfer</a>(<var>message</var>, <var>transfer</var>). Rethrow any exceptions.</p>
       <li data-md="">
        <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task" id="ref-for-queue-a-task④">Queue a task</a> from the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/web-messaging.html#posted-message-task-source" id="ref-for-posted-message-task-source">posted message task source</a> to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop" id="ref-for-event-loop③">event loop</a> of <var>portalBrowsingContext</var> to run the following steps:</p>
        <ol>
@@ -1692,7 +1693,7 @@ abort these steps.</p>
         <li data-md="">
          <p>Let <var>targetRealm</var> be the <var>targetWindow</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm" id="ref-for-environment-settings-object&apos;s-realm①">realm</a>.</p>
         <li data-md="">
-         <p>Let <var>deserializeRecord</var> be <a data-link-type="abstract-op" href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserializewithtransfer" id="ref-for-structureddeserializewithtransfer">StructuredDeserializeWithTransfer</a>(<var>serializeWithTransferResult</var>, <var>targetRealm</var>).</p>
+         <p>Let <var>deserializeRecord</var> be <a data-link-type="abstract-op" href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserializewithtransfer" id="ref-for-structureddeserializewithtransfer①">StructuredDeserializeWithTransfer</a>(<var>serializeWithTransferResult</var>, <var>targetRealm</var>).</p>
          <p>If this throws an exception, catch it, <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire" id="ref-for-concept-event-fire">fire an event</a> named <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-portalhost-messageerror" id="ref-for-eventdef-portalhost-messageerror">messageerror</a></code> at <var>portalHost</var> using <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/comms.html#messageevent" id="ref-for-messageevent">MessageEvent</a></code> with the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-origin" id="ref-for-dom-messageevent-origin">origin</a></code> attribute initialized to <var>origin</var> and the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-source" id="ref-for-dom-messageevent-source">source</a></code> attribute initialized to <var>portalHost</var>,
 then abort these steps.</p>
         <li data-md="">
@@ -1719,7 +1720,7 @@ initialized to <var>messageClone</var>, and the <code class="idl"><a data-link-t
       <li data-md="">
        <p>Let <var>targetRealm</var> be <var>settings</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm" id="ref-for-environment-settings-object&apos;s-realm②">realm</a>.</p>
       <li data-md="">
-       <p>Let <var>deserializeRecord</var> be <a data-link-type="abstract-op" href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserializewithtransfer" id="ref-for-structureddeserializewithtransfer①">StructuredDeserializeWithTransfer</a>(<var>serializeWithTransferResult</var>, <var>targetRealm</var>).</p>
+       <p>Let <var>deserializeRecord</var> be <a data-link-type="abstract-op" href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserializewithtransfer" id="ref-for-structureddeserializewithtransfer②">StructuredDeserializeWithTransfer</a>(<var>serializeWithTransferResult</var>, <var>targetRealm</var>).</p>
        <p>If this throws an exception, catch it, <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire" id="ref-for-concept-event-fire②">fire an event</a> named <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-htmlportalelement-messageerror" id="ref-for-eventdef-htmlportalelement-messageerror">messageerror</a></code> at the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object" id="ref-for-context-object⑤">context object</a> using <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/comms.html#messageevent" id="ref-for-messageevent②">MessageEvent</a></code> with the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-origin" id="ref-for-dom-messageevent-origin②">origin</a></code> attribute initialized to <var>origin</var> and the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-source" id="ref-for-dom-messageevent-source②">source</a></code> attribute initialized to the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object" id="ref-for-context-object⑥">context object</a>,</p>
       <li data-md="">
        <p>Let <var>messageClone</var> be <var>deserializeRecord</var>.[[Deserialized]].</p>
@@ -1812,7 +1813,7 @@ Otherwise, let <var>url</var> be the <a data-link-type="dfn" href="https://html.
     <div class="note" role="note"> The <a data-link-type="dfn" href="#portal-host-object" id="ref-for-portal-host-object④">portal host object</a> can be used to communicate with the <a data-link-type="dfn" href="#host" id="ref-for-host④">host</a> of a <a data-link-type="dfn" href="#portal-browsing-context" id="ref-for-portal-browsing-context⑧">portal browsing context</a>.
     Its operations throw if used while it’s context is not a <a data-link-type="dfn" href="#portal-browsing-context" id="ref-for-portal-browsing-context⑨">portal browsing context</a> (i.e. there is no host). </div>
 <pre class="idl highlight def"><span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="portalhost"><code>PortalHost</code></dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget">EventTarget</a> {
-    <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-portalhost-postmessage" id="ref-for-dom-portalhost-postmessage">postMessage</a>(<span class="kt">any</span> <dfn class="nv idl-code" data-dfn-for="PortalHost/postMessage(message, targetOrigin, transfer), PortalHost/postMessage(message, targetOrigin)" data-dfn-type="argument" data-export="" id="dom-portalhost-postmessage-message-targetorigin-transfer-message"><code>message</code><a class="self-link" href="#dom-portalhost-postmessage-message-targetorigin-transfer-message"></a></dfn>, <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="PortalHost/postMessage(message, targetOrigin, transfer), PortalHost/postMessage(message, targetOrigin)" data-dfn-type="argument" data-export="" id="dom-portalhost-postmessage-message-targetorigin-transfer-targetorigin"><code>targetOrigin</code><a class="self-link" href="#dom-portalhost-postmessage-message-targetorigin-transfer-targetorigin"></a></dfn>, <span class="kt">optional</span> <span class="kt">sequence</span>&lt;<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-object" id="ref-for-idl-object①"><span class="kt">object</span></a>> <dfn class="nv idl-code" data-dfn-for="PortalHost/postMessage(message, targetOrigin, transfer), PortalHost/postMessage(message, targetOrigin)" data-dfn-type="argument" data-export="" id="dom-portalhost-postmessage-message-targetorigin-transfer-transfer"><code>transfer</code><a class="self-link" href="#dom-portalhost-postmessage-message-targetorigin-transfer-transfer"></a></dfn> = []);
+    <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-portalhost-postmessage" id="ref-for-dom-portalhost-postmessage">postMessage</a>(<span class="kt">any</span> <dfn class="nv idl-code" data-dfn-for="PortalHost/postMessage(message, targetOrigin, transfer), PortalHost/postMessage(message, targetOrigin)" data-dfn-type="argument" data-export="" id="dom-portalhost-postmessage-message-targetorigin-transfer-message"><code>message</code><a class="self-link" href="#dom-portalhost-postmessage-message-targetorigin-transfer-message"></a></dfn>, <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="PortalHost/postMessage(message, targetOrigin, transfer), PortalHost/postMessage(message, targetOrigin)" data-dfn-type="argument" data-export="" id="dom-portalhost-postmessage-message-targetorigin-transfer-targetorigin"><code>targetOrigin</code><a class="self-link" href="#dom-portalhost-postmessage-message-targetorigin-transfer-targetorigin"></a></dfn>, <span class="kt">optional</span> <span class="kt">sequence</span>&lt;<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-object" id="ref-for-idl-object②"><span class="kt">object</span></a>> <dfn class="nv idl-code" data-dfn-for="PortalHost/postMessage(message, targetOrigin, transfer), PortalHost/postMessage(message, targetOrigin)" data-dfn-type="argument" data-export="" id="dom-portalhost-postmessage-message-targetorigin-transfer-transfer"><code>transfer</code><a class="self-link" href="#dom-portalhost-postmessage-message-targetorigin-transfer-transfer"></a></dfn> = []);
 };
 </pre>
     <div class="issue" id="issue-ca552fc8①"><a class="self-link" href="#issue-ca552fc8①"></a> This should also include a <code>PostMessageOptions</code> dictionary overload, to reflect the changes due to the <a href="https://github.com/dtapuska/useractivation">user activation proposal</a>. </div>
@@ -1829,7 +1830,7 @@ throw an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.
       <li data-md="">
        <p>If <var>targetOrigin</var> is a single U+002F SOLIDUS character (/), then set <var>targetOrigin</var> to the <a href="https://html.spec.whatwg.org/multipage/#concept-settings-object-origin">origin</a> of <var>settings</var>.</p>
       <li data-md="">
-       <p>Let <var>serializeWithTransferResult</var> be <a data-link-type="abstract-op" href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer" id="ref-for-structuredserializewithtransfer①">StructuredSerializeWithTransfer</a>(<var>message</var>, <var>transfer</var>). Rethrow any exceptions.</p>
+       <p>Let <var>serializeWithTransferResult</var> be <a data-link-type="abstract-op" href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer" id="ref-for-structuredserializewithtransfer②">StructuredSerializeWithTransfer</a>(<var>message</var>, <var>transfer</var>). Rethrow any exceptions.</p>
       <li data-md="">
        <p>Run the steps to <a data-link-type="dfn" href="#accept-a-message-posted-to-the-host" id="ref-for-accept-a-message-posted-to-the-host①">accept a message posted to the host</a> for the <a data-link-type="dfn" href="#host" id="ref-for-host⑤">host</a> associated with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object" id="ref-for-context-object②④">context object</a> with <var>serializeWithTransferResult</var>, <var>origin</var> and <var>targetOrigin</var>.</p>
      </ol>
@@ -2118,6 +2119,7 @@ throw an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.
    <li><a href="#portalactivateevent-predecessor-browsing-context">predecessor browsing context</a><span>, in §3.3</span>
    <li><a href="#htmlportalelement-set-the-source-url-of-a-portal-element">set the source URL of a portal element</a><span>, in §3.1</span>
    <li><a href="#dom-htmlportalelement-src">src</a><span>, in §3.1</span>
+   <li><a href="#dom-portalactivateoptions-transfer">transfer</a><span>, in §3.1</span>
   </ul>
   <aside class="dfn-panel" data-for="term-for-document">
    <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
@@ -2257,29 +2259,18 @@ throw an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.
     <li><a href="#ref-for-messageport②">3.4. Miscellaneous extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structureddeserialize">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize">https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-structureddeserialize">2. Concepts</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="term-for-structureddeserializewithtransfer">
    <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserializewithtransfer">https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserializewithtransfer</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-structureddeserializewithtransfer">3.1. The portal element</a> <a href="#ref-for-structureddeserializewithtransfer①">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-structuredserialize">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserialize">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserialize</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-structuredserialize">3.1. The portal element</a>
+    <li><a href="#ref-for-structureddeserializewithtransfer">2. Concepts</a>
+    <li><a href="#ref-for-structureddeserializewithtransfer①">3.1. The portal element</a> <a href="#ref-for-structureddeserializewithtransfer②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-structuredserializewithtransfer">
    <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-structuredserializewithtransfer">3.1. The portal element</a>
-    <li><a href="#ref-for-structuredserializewithtransfer①">3.2. The PortalHost interface</a>
+    <li><a href="#ref-for-structuredserializewithtransfer">3.1. The portal element</a> <a href="#ref-for-structuredserializewithtransfer①">(2)</a>
+    <li><a href="#ref-for-structuredserializewithtransfer②">3.2. The PortalHost interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-window">
@@ -2551,8 +2542,8 @@ throw an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.
   <aside class="dfn-panel" data-for="term-for-idl-object">
    <a href="https://heycam.github.io/webidl/#idl-object">https://heycam.github.io/webidl/#idl-object</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-object">3.1. The portal element</a>
-    <li><a href="#ref-for-idl-object①">3.2. The PortalHost interface</a>
+    <li><a href="#ref-for-idl-object">3.1. The portal element</a> <a href="#ref-for-idl-object①">(2)</a>
+    <li><a href="#ref-for-idl-object②">3.2. The PortalHost interface</a>
    </ul>
   </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
@@ -2594,9 +2585,7 @@ throw an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.
      <li><span class="dfn-paneled" id="term-for-htmlelement" style="color:initial">HTMLElement</span>
      <li><span class="dfn-paneled" id="term-for-messageevent" style="color:initial">MessageEvent</span>
      <li><span class="dfn-paneled" id="term-for-messageport" style="color:initial">MessagePort</span>
-     <li><span class="dfn-paneled" id="term-for-structureddeserialize" style="color:initial">StructuredDeserialize</span>
      <li><span class="dfn-paneled" id="term-for-structureddeserializewithtransfer" style="color:initial">StructuredDeserializeWithTransfer</span>
-     <li><span class="dfn-paneled" id="term-for-structuredserialize" style="color:initial">StructuredSerialize</span>
      <li><span class="dfn-paneled" id="term-for-structuredserializewithtransfer" style="color:initial">StructuredSerializeWithTransfer</span>
      <li><span class="dfn-paneled" id="term-for-window" style="color:initial">Window</span>
      <li><span class="dfn-paneled" id="term-for-windowproxy" style="color:initial">WindowProxy</span>
@@ -2692,15 +2681,16 @@ throw an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.
 <span class="kt">interface</span> <a class="nv" href="#htmlportalelement"><code>HTMLPortalElement</code></a> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement" id="ref-for-htmlelement①">HTMLElement</a> {
     [<a class="nv idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①">CEReactions</a>] <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①"><span class="kt">USVString</span></a> <a class="nv" data-type="USVString" href="#dom-htmlportalelement-src"><code>src</code></a>;
     [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject" id="ref-for-NewObject①">NewObject</a>] <span class="kt">Promise</span>&lt;<span class="kt">void</span>> <a class="nv idl-code" data-link-type="method" href="#dom-htmlportalelement-activate" id="ref-for-dom-htmlportalelement-activate①①">activate</a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-portalactivateoptions" id="ref-for-dictdef-portalactivateoptions①">PortalActivateOptions</a> <a class="nv" href="#dom-htmlportalelement-activate-options-options"><code>options</code></a>);
-    <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-htmlportalelement-postmessage" id="ref-for-dom-htmlportalelement-postmessage①">postMessage</a>(<span class="kt">any</span> <a class="nv" href="#dom-htmlportalelement-postmessage-message-targetorigin-transfer-message"><code>message</code></a>, <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-htmlportalelement-postmessage-message-targetorigin-transfer-targetorigin"><code>targetOrigin</code></a>, <span class="kt">optional</span> <span class="kt">sequence</span>&lt;<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-object" id="ref-for-idl-object②"><span class="kt">object</span></a>> <a class="nv" href="#dom-htmlportalelement-postmessage-message-targetorigin-transfer-transfer"><code>transfer</code></a> = []);
+    <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-htmlportalelement-postmessage" id="ref-for-dom-htmlportalelement-postmessage①">postMessage</a>(<span class="kt">any</span> <a class="nv" href="#dom-htmlportalelement-postmessage-message-targetorigin-transfer-message"><code>message</code></a>, <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-htmlportalelement-postmessage-message-targetorigin-transfer-targetorigin"><code>targetOrigin</code></a>, <span class="kt">optional</span> <span class="kt">sequence</span>&lt;<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-object" id="ref-for-idl-object③"><span class="kt">object</span></a>> <a class="nv" href="#dom-htmlportalelement-postmessage-message-targetorigin-transfer-transfer"><code>transfer</code></a> = []);
 };
 
 <span class="kt">dictionary</span> <a class="nv" href="#dictdef-portalactivateoptions"><code>PortalActivateOptions</code></a> {
     <span class="kt">any</span> <a class="nv" data-default="null" data-type="any " href="#dom-portalactivateoptions-data"><code>data</code></a> = <span class="kt">null</span>;
+    <span class="kt">sequence</span>&lt;<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-object" id="ref-for-idl-object①①"><span class="kt">object</span></a>> <a class="nv" data-default="None" data-type="sequence<object> " href="#dom-portalactivateoptions-transfer"><code>transfer</code></a> = [];
 };
 
 <span class="kt">interface</span> <a class="nv" href="#portalhost"><code>PortalHost</code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget①">EventTarget</a> {
-    <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-portalhost-postmessage" id="ref-for-dom-portalhost-postmessage①">postMessage</a>(<span class="kt">any</span> <a class="nv" href="#dom-portalhost-postmessage-message-targetorigin-transfer-message"><code>message</code></a>, <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①①"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-portalhost-postmessage-message-targetorigin-transfer-targetorigin"><code>targetOrigin</code></a>, <span class="kt">optional</span> <span class="kt">sequence</span>&lt;<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-object" id="ref-for-idl-object①①"><span class="kt">object</span></a>> <a class="nv" href="#dom-portalhost-postmessage-message-targetorigin-transfer-transfer"><code>transfer</code></a> = []);
+    <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-portalhost-postmessage" id="ref-for-dom-portalhost-postmessage①">postMessage</a>(<span class="kt">any</span> <a class="nv" href="#dom-portalhost-postmessage-message-targetorigin-transfer-message"><code>message</code></a>, <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①①"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-portalhost-postmessage-message-targetorigin-transfer-targetorigin"><code>targetOrigin</code></a>, <span class="kt">optional</span> <span class="kt">sequence</span>&lt;<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-object" id="ref-for-idl-object②①"><span class="kt">object</span></a>> <a class="nv" href="#dom-portalhost-postmessage-message-targetorigin-transfer-transfer"><code>transfer</code></a> = []);
 };
 
 <span class="kt">interface</span> <a class="nv" href="#portalactivateevent"><code>PortalActivateEvent</code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event" id="ref-for-event①">Event</a> {
@@ -2804,6 +2794,12 @@ throw an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.
    <b><a href="#dom-portalactivateoptions-data">#dom-portalactivateoptions-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-portalactivateoptions-data">3.1. The portal element</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-portalactivateoptions-transfer">
+   <b><a href="#dom-portalactivateoptions-transfer">#dom-portalactivateoptions-transfer</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-portalactivateoptions-transfer">3.1. The portal element</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="complete-portal-activation">


### PR DESCRIPTION
Uses `StructuredSerialize`, which doesn't allow transfer but is simple.

Resolves #28.